### PR TITLE
Rework the way the tags are assigned to the role

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | account\_ids | AWS account IDs that are allowed to assume the role. | `list(string)` | `[]` | no |
+| additional\_role\_tags | Tags to apply to the IAM role that allows read-only access to the specified S3 buckets, in addition to the provider's default tags. | `map(string)` | `{}` | no |
 | aws\_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | entity\_name | The name of the entity that the role is being created for (e.g. "test-user"). | `string` | n/a | yes |
 | iam\_usernames | The list of IAM usernames allowed to assume the role.  If not provided, defaults to allowing any user in the specified account(s).  Note that including "root" in this list will override any other usernames in the list. | `list(string)` | `["root"]` | no |
 | role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the specified object(s) in the specified S3 buckets.  Note that the first "%s" in this value will get replaced with the s3\_bucket variable and the second "%s" will get replaced with the entity\_name variable. | `string` | `"Allows read-only access to S3 bucket %s required for %s."` | no |
 | role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the specified S3 buckets.  Note that the first "%s" in this value will get replaced with the s3\_bucket variable and the second "%s" will get replaced with the entity\_name variable. | `string` | `"%s-ReadOnly-%s"` | no |
-| role\_tags | Tags to apply to the IAM role that allows read-only access to the specified S3 buckets. | `map(string)` | `{}` | no |
 | s3\_bucket | The name of the S3 bucket that the created role will be allowed to read from (e.g. "my-bucket"). | `string` | n/a | yes |
 | s3\_objects | A list specifying the objects in the S3 bucket that the created role will be allowed to read (e.g. ["my-file", "projects\example\*"]).  AWS-supported S3 ARN wildcards (* and ?) can be used, but full regular expressions can not.  If not specified, the role will be allowed to read any object in the bucket. | `list(string)` | `["*"]` | no |
 

--- a/role.tf
+++ b/role.tf
@@ -26,7 +26,7 @@ resource "aws_iam_role" "s3_read" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   description        = local.role_description
   name               = local.role_name
-  tags               = var.role_tags
+  tags               = var.additional_role_tags
 }
 
 # Attach the policy to the role

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "account_ids" {
   default     = []
 }
 
+variable "additional_role_tags" {
+  type        = map(string)
+  description = "Tags to apply to the IAM role that allows read-only access to the specified S3 buckets, in addition to the provider's default tags."
+  default     = {}
+}
+
 variable "aws_region" {
   type        = string
   description = "The AWS region where the non-global resources are to be provisioned (e.g. \"us-east-1\")."
@@ -48,12 +54,6 @@ variable "role_name" {
   type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the specified S3 buckets.  Note that the first \"%s\" in this value will get replaced with the s3_bucket variable and the second \"%s\" will get replaced with the entity_name variable."
   default     = "%s-ReadOnly-%s"
-}
-
-variable "role_tags" {
-  type        = map(string)
-  description = "Tags to apply to the IAM role that allows read-only access to the specified S3 buckets."
-  default     = {}
 }
 
 variable "s3_objects" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request reworks the way tags are assigned to the role, as discussed in [this pull request](https://github.com/cisagov/s3-read-role-tf-module/pull/14#pullrequestreview-683231901).

## 💭 Motivation and context ##

Now that we are using default tags in our providers, we need to rework the way tags are assigned to the role resource.  This is because the provider's default tags will be assigned to the role resource, and if those tags are identical to the tags assigned explicitly then `terraform` returns an error.

The solution is to remove the `role_tags` variable and replace it with an `additional_role_tags` variable.  This variable contains _only_ the tags to be assigned to the role resource _in addition to_ the provider's default tags.

One thing this solution _does not_ offer (directly) is the ability to provide a list of tags that _should not_ be applied to the role resource.  This is [occasionally useful to avoid applying a `Workspace` tag](https://github.com/cisagov/cool-userservices-dns/blob/455727b2e0ebdc2af5942766f1d70249e6a9d3c3/read_terraform_state_role.tf#L23), for example.  This can be achieved, though, by appropriately configuring the default tags of the provider used to create the resource.

## 🧪 Testing ##

I successfully used these changes to apply the changes from cisagov/ansible-role-cobalt-strike#35.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
